### PR TITLE
fix: support pornhubpremium flashvars extraction

### DIFF
--- a/public/js/get-ph-flashvars.js
+++ b/public/js/get-ph-flashvars.js
@@ -18,11 +18,12 @@
     return cache.map[vkey] || null;
   }
 
-  function postMediaDefinitions(mediaDefinitions) {
+  function postMediaDefinitions(mediaDefinitions, flashvarsData) {
     if (!mediaDefinitions) return;
     window.postMessage({
       type: 'get-ph-flashvars',
       data: mediaDefinitions,
+      video_title: flashvarsData && flashvarsData.video_title,
     });
   }
 
@@ -132,7 +133,7 @@
 
     if (item && item.mediaDefinitions) {
       setShortiesCache(vkey, item.mediaDefinitions);
-      postMediaDefinitions(item.mediaDefinitions);
+      postMediaDefinitions(item.mediaDefinitions, item);
       return;
     }
 
@@ -147,7 +148,7 @@
         var fetchedItem = fetchedList ? findItemByVkey(fetchedList, vkey) : null;
         if (fetchedItem && fetchedItem.mediaDefinitions) {
           setShortiesCache(vkey, fetchedItem.mediaDefinitions);
-          postMediaDefinitions(fetchedItem.mediaDefinitions);
+          postMediaDefinitions(fetchedItem.mediaDefinitions, fetchedItem);
         }
       })
       .catch(function () {});
@@ -156,18 +157,36 @@
   }
 
   // 2) Regular video page: use flashvars_XXXX.mediaDefinitions
-  var jsString = (
-    document.querySelector('#mobileContainer >script:nth-child(1)') ||
-    document.querySelector('#player >script:nth-child(1)')
-  )?.innerHTML;
-  if (!jsString) return;
+  function getFlashvarsNameFromScripts() {
+    var knownScript = (
+      document.querySelector('#mobileContainer >script:nth-child(1)') ||
+      document.querySelector('#player >script:nth-child(1)')
+    )?.innerHTML;
+    var knownMatch = knownScript && knownScript.match(/flashvars_[0-9]{1,}/);
+    if (knownMatch && knownMatch[0]) return knownMatch[0];
 
-  var flashvarsMatch = jsString.match('flashvars_[0-9]{1,}');
-  if (!flashvarsMatch || !flashvarsMatch[0]) return;
+    var scripts = document.querySelectorAll('script');
+    for (var i = 0; i < scripts.length; i++) {
+      var html = scripts[i].innerHTML || scripts[i].textContent || '';
+      var match = html.match(/flashvars_[0-9]{1,}/);
+      if (match && match[0]) return match[0];
+    }
 
-  var flashvars = flashvarsMatch[0];
+    return '';
+  }
+
+  function getFlashvarsNameFromWindow() {
+    for (var prop in window) {
+      if (/^flashvars_[0-9]{1,}$/.test(prop)) return prop;
+    }
+    return '';
+  }
+
+  var flashvars = getFlashvarsNameFromScripts() || getFlashvarsNameFromWindow();
+  if (!flashvars) return;
+
   console.log('🚀 ~ handleMessage ~ flashvars:', flashvars);
   if (window[flashvars] && window[flashvars].mediaDefinitions) {
-    postMediaDefinitions(window[flashvars].mediaDefinitions);
+    postMediaDefinitions(window[flashvars].mediaDefinitions, window[flashvars]);
   }
 })();

--- a/src/pages/content/injected/hostMapGetUrls.ts
+++ b/src/pages/content/injected/hostMapGetUrls.ts
@@ -131,12 +131,15 @@ const getPornhubUrls = createMessageHandler({
   scriptPath: 'js/get-ph-flashvars.js',
   handler: async (event, resolve) => {
     console.log('recived message:', event.data);
-    const mp4UrlInfo = event.data.data.find((val: any) => val.format === 'mp4');
-    const m3u8UrlInfo = event.data?.data
+    const data = event.data?.data || [];
+    const videoTitle = event.data?.video_title || title;
+    const mp4UrlInfo = data.find((val: any) => val.format === 'mp4');
+    const m3u8UrlInfo = data
       ?.filter((val: any) => val.format === 'hls')
       .map((val: any) => ({
         ...val,
         format: 'm3u8',
+        title: videoTitle,
       }));
 
     // Fetch m3u8 content and extract real video URLs
@@ -174,17 +177,33 @@ const getPornhubUrls = createMessageHandler({
       document.querySelector('.video-actions-container .usernameBadgesWrapper a')?.innerHTML ||
       document.querySelector<HTMLAnchorElement>('userInfoContainer > a')?.innerText ||
       '';
+    const fileName = [usr, videoTitle].filter(Boolean).join('--');
+
+    const fallbackResult = (m3u8UrlInfoWithRealUrls || []).map((val: any) => ({
+      ...val,
+      title: fileName || val.title || title,
+    }));
 
     if (mp4UrlInfo) {
-      const mp4InfoList = (await fetch(mp4UrlInfo.videoUrl).then(res => res.json()))?.map((val: any) => ({
-        ...val,
-        title: usr + '--' + title,
-      }));
+      let mp4InfoList: any[] = [];
+      try {
+        mp4InfoList =
+          (await fetch(mp4UrlInfo.videoUrl).then(res => res.json()))?.map((val: any) => ({
+            ...val,
+            title: fileName || title,
+          })) || [];
+      } catch (error) {
+        console.error('Failed to fetch Pornhub MP4 info:', error);
+      }
 
-      const result = mp4InfoList.concat(m3u8UrlInfoWithRealUrls || []);
+      const result = mp4InfoList.concat(fallbackResult);
       cache.pornhub = result;
       resolve(result);
+      return;
     }
+
+    cache.pornhub = fallbackResult;
+    resolve(fallbackResult);
   },
 });
 
@@ -249,6 +268,9 @@ const getRedtube = createMessageHandler({
 });
 const hostMapGetUrls = {
   'pornhub.com': {
+    getUrls: getPornhubUrls,
+  },
+  'pornhubpremium.com': {
     getUrls: getPornhubUrls,
   },
   'xvideos.com': {


### PR DESCRIPTION
Fixes #14.

Changes:
- Add `pornhubpremium.com` to the supported host map.
- Make the Pornhub flashvars injector find `flashvars_*` in additional script locations and via `window` fallback.
- Return HLS entries when MP4 metadata fetching fails or no MP4 entry exists, so Premium pages still expose downloadable formats.

Validation:
- `npx pnpm@8.9.2 exec eslint src/pages/content/injected/hostMapGetUrls.ts`
- `node --check public/js/get-ph-flashvars.js`

Notes:
- `npx pnpm@8.9.2 test -- --run` still fails in the existing UI test with React/Preact ref configuration before reaching this change.
- `npx pnpm@8.9.2 build` is blocked because the `video-download-core` submodule is not accessible from this environment.