### PR TITLE
fix: restore broken star history chart

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -103,11 +103,11 @@
 
 ## Star History
 
-<a href="https://star-history.com/#webLiang/Pornhub-Video-Downloader-Plugin-v3&Date">
+<a href="https://star-history.dera.page/#webLiang/Pornhub-Video-Downloader-Plugin-v3&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
   </picture>
 </a>
 

--- a/README.en.md
+++ b/README.en.md
@@ -104,10 +104,10 @@ Quetta also ships an official multi-platform video downloader extension — work
 
 ## Star History
 
-<a href="https://star-history.com/#webLiang/Pornhub-Video-Downloader-Plugin-v3&Date">
+<a href="https://star-history.dera.page/#webLiang/Pornhub-Video-Downloader-Plugin-v3&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
   </picture>
 </a>

--- a/README.es.md
+++ b/README.es.md
@@ -103,11 +103,11 @@ Quetta también ofrece una extensión oficial multiplataforma para descargar vid
 
 ## Star History
 
-<a href="https://star-history.com/#webLiang/Pornhub-Video-Downloader-Plugin-v3&Date">
+<a href="https://star-history.dera.page/#webLiang/Pornhub-Video-Downloader-Plugin-v3&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
   </picture>
 </a>
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -103,11 +103,11 @@ Quetta एक आधिकारिक मल्टी-प्लेटफ़ॉ�
 
 ## Star History
 
-<a href="https://star-history.com/#webLiang/Pornhub-Video-Downloader-Plugin-v3&Date">
+<a href="https://star-history.dera.page/#webLiang/Pornhub-Video-Downloader-Plugin-v3&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
   </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ Quetta also ships an official multi-platform video downloader extension — work
 
 ## Star History
 
-<a href="https://star-history.com/#webLiang/Pornhub-Video-Downloader-Plugin-v3&Date">
+<a href="https://star-history.dera.page/#webLiang/Pornhub-Video-Downloader-Plugin-v3&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
   </picture>
 </a>

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -104,11 +104,11 @@ Quetta 同时提供一款官方的多平台视频下载插件，支持 **YouTube
 
 ## Star History
 
-<a href="https://star-history.com/#webLiang/Pornhub-Video-Downloader-Plugin-v3&Date">
+<a href="https://star-history.dera.page/#webLiang/Pornhub-Video-Downloader-Plugin-v3&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=webLiang/Pornhub-Video-Downloader-Plugin-v3&type=Date" />
   </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the READMEs is currently broken and renders nothing, which is unfortunate since the project has earned a meaningful number of stars. This updates the chart image and its link to a working service so the chart shows up again. Applied consistently across the main README and all localized versions.